### PR TITLE
Refactoring & conflict fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ group = project.maven_group
 
 loom {
 	mixin.defaultRefmapName.set("fixbookgui-refmap.json")
+	accessWidenerPath.set(file("src/main/resources/fixbookgui.accesswidener"))
 }
 
 dependencies {

--- a/src/main/java/net/kosmo/fixbookgui/FixBookGui.java
+++ b/src/main/java/net/kosmo/fixbookgui/FixBookGui.java
@@ -4,11 +4,18 @@ import com.mojang.logging.LogUtils;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ingame.BookScreen;
 
 @Environment(EnvType.CLIENT)
 public class FixBookGui implements ClientModInitializer {
-        @Override
-        public void onInitializeClient() {
-            LogUtils.getLogger().info("FixBookGui initialized");
-        }
+
+    public static int getFixedY(Screen screen) {
+        return (screen.height - BookScreen.HEIGHT) / 3;
+    }
+
+    @Override
+    public void onInitializeClient() {
+        LogUtils.getLogger().info("FixBookGui initialized");
+    }
 }

--- a/src/main/java/net/kosmo/fixbookgui/mixins/MixinLecternScreen.java
+++ b/src/main/java/net/kosmo/fixbookgui/mixins/MixinLecternScreen.java
@@ -1,17 +1,17 @@
 package net.kosmo.fixbookgui.mixins;
 
+import net.kosmo.fixbookgui.FixBookGui;
+import net.minecraft.client.gui.Drawable;
 import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.Selectable;
 import net.minecraft.client.gui.screen.ingame.BookScreen;
 import net.minecraft.client.gui.screen.ingame.LecternScreen;
 import net.minecraft.client.gui.screen.ingame.ScreenHandlerProvider;
-import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.Widget;
 import net.minecraft.screen.LecternScreenHandler;
-import net.minecraft.screen.ScreenTexts;
-import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
  * @author KosmoMoustache
@@ -19,27 +19,22 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
  */
 @Mixin(LecternScreen.class)
 public abstract class MixinLecternScreen extends BookScreen implements ScreenHandlerProvider<LecternScreenHandler> {
+
     protected MixinLecternScreen() {
         super(null);
     }
 
-    @Shadow
-    private void sendButtonPressPacket(int i) {
-    }
-
-    private int getY() {
-        return (this.height - 192) / 3 + 196;
-    }
-
-    @ModifyArg(method = "addCloseButton", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/LecternScreen;addDrawableChild(Lnet/minecraft/client/gui/Element;)Lnet/minecraft/client/gui/Element;", ordinal = 0))
-    public Element fbg$addCloseButton1(Element par1) {
-        return ButtonWidget.builder(ScreenTexts.DONE, (button) -> this.close())
-                .dimensions(this.width / 2 - 100, getY(), 98, 20).build();
-    }
-
-    @ModifyArg(method = "addCloseButton", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/LecternScreen;addDrawableChild(Lnet/minecraft/client/gui/Element;)Lnet/minecraft/client/gui/Element;", ordinal = 1))
-    public Element fbg$addCloseButton2(Element par1) {
-        return ButtonWidget.builder(Text.translatable("lectern.take_book"), (button) -> this.sendButtonPressPacket(3))
-                .dimensions(this.width / 2 + 2, getY(), 98, 20).build();
+    @Redirect(
+            method = "addCloseButton",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/gui/screen/ingame/LecternScreen;addDrawableChild(Lnet/minecraft/client/gui/Element;)Lnet/minecraft/client/gui/Element;"
+            )
+    )
+    public <T extends Element & Drawable & Selectable> T fbg$translateButtons(LecternScreen screen, T element) {
+        if (element instanceof Widget widget) {
+            widget.setY(widget.getY() + FixBookGui.getFixedY(this));
+        }
+        return screen.addDrawableChild(element);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,5 +30,6 @@
   "depends": {
     "minecraft": ">=1.20.4",
     "fabricloader": ">=0.15.1"
-  }
+  },
+  "accessWidener": "fixbookgui.accesswidener"
 }

--- a/src/main/resources/fixbookgui.accesswidener
+++ b/src/main/resources/fixbookgui.accesswidener
@@ -1,0 +1,5 @@
+accessWidener v2 named
+
+accessible method net/minecraft/client/gui/screen/Screen addDrawableChild (Lnet/minecraft/client/gui/Element;)Lnet/minecraft/client/gui/Element;
+
+accessible field net/minecraft/client/gui/screen/ingame/BookScreen HEIGHT I


### PR DESCRIPTION
# Huh?

Hello! I'm making a mod that also makes changes to the GUI of the book, and I had a mixin conflict. The problem is that your code is currently doing more than it should. Instead of changing the code associated with the Y coordinate, your mod overwrites some of the vanilla code in different places. This is what bothered me, so I decided to open this pull request.

# Changes

- Instead of changing the Y coordinate for all UI components separately, I move the `matrices` using `translate(x, y)` method. Thanks to this we shift the entire interface.
- Instead of duplicating `ButtonWidget.Builder` code we shift only what we need - the Y coordinate.
- More readable code and method order in mixins.
- The method that returns Y relative to the screen has been moved to the `FixBookGui`, instead of being duplicated in 3 mixins.
- For the new code it was necessary to add `accesswidener` to access some closed Vanilla code.